### PR TITLE
Parse: do prefix check before len check

### DIFF
--- a/prettyuuid.go
+++ b/prettyuuid.go
@@ -80,12 +80,12 @@ func (f *Format) Format(uuid [16]byte) string {
 
 // Parse converts a pretty string to a UUID.
 func (f *Format) Parse(s string) ([16]byte, error) {
-	if len(s) != f.len() {
-		return [16]byte{}, fmt.Errorf("%q does not have expected length %v", s, f.len())
-	}
-
 	if !strings.HasPrefix(s, f.prefix) {
 		return [16]byte{}, fmt.Errorf("%q does not have expected prefix %q", s, f.prefix)
+	}
+
+	if len(s) != f.len() {
+		return [16]byte{}, fmt.Errorf("%q does not have expected length %v", s, f.len())
 	}
 
 	var n big.Int

--- a/prettyuuid_test.go
+++ b/prettyuuid_test.go
@@ -75,6 +75,12 @@ func TestFormat_Parse(t *testing.T) {
 			ID:      "0000000000000000000000000000000x",
 			WantErr: `"0000000000000000000000000000000x" contains illegal char at position 31`,
 		},
+		{
+			Name:    "bad length and bad prefix",
+			Format:  prettyuuid.MustNewFormat("prefix_", "0123456789abcdef"),
+			ID:      "notprefix_00000000000000000000000000000000x",
+			WantErr: `"notprefix_00000000000000000000000000000000x" does not have expected prefix "prefix_"`,
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
In practice, it's far more common for bad IDs to simply be of the wrong "type" than for the UUID part to be mangled. This PR has Parse do the prefix check first, that way users in practice get much more helpful errors about having the wrong kind of ID than about having the wrong length.